### PR TITLE
fix: set seconds to type int in timedelta

### DIFF
--- a/python-demo/strategy/pure_perp_market_making/perp_simple_strategy.py
+++ b/python-demo/strategy/pure_perp_market_making/perp_simple_strategy.py
@@ -64,7 +64,7 @@ class Demo(PerpTemplate):
                            seconds=self.interval, id="timer")
 
         self.sched.add_job(self.close_position, 'interval',
-                           seconds=self.re_balance_interval_hour * 3600, id="re_balance_position")
+                           seconds=int(self.re_balance_interval_hour) * 3600, id="re_balance_position")
     def subscribe_stream(self):
         self.tasks = [
             asyncio.Task(self.stream_order(self.market_id, self.acc_id)),


### PR DESCRIPTION
Fixes:
<img width="967" alt="Screenshot 2022-01-24 at 12 48 26 PM" src="https://user-images.githubusercontent.com/83584143/150769679-0bf5353a-9c4a-4951-89fe-e330928bc83c.png">

